### PR TITLE
Feature/se3 4 create common space for stones

### DIFF
--- a/src/app/services/socket.service.ts
+++ b/src/app/services/socket.service.ts
@@ -32,10 +32,8 @@ export class SocketService {
       return new Observable<any>(observer => {
           this.socket.emit(chanel, message, function (data) {
               if (data.success) {
-                  // Успех
                   observer.next(data.msg);
               } else {
-                  // Что-то пошло не так
                   observer.error(data.msg);
               }
               observer.complete();
@@ -46,7 +44,7 @@ export class SocketService {
   on(event_name) {
     console.log(`listen to ${event_name}:`);
     return new Observable<any>(observer => {
-        this.socket.off(event_name);
+      //  this.socket.off(event_name);
         this.socket.on(event_name, (data) => {
             observer.next(data);
         });

--- a/src/app/services/stones.service.ts
+++ b/src/app/services/stones.service.ts
@@ -26,30 +26,32 @@ interface IStone {
 
   export class StonesService {
 
-    stones: IStone[];
+    stonesInventory: IStone[];
     dragPosition: IPixelPosition;
     canvas: HTMLCanvasElement;
     ctx: CanvasRenderingContext2D;
     stoneRadius = 10;
+    // Current stone when is dragging
     stone: IStone;
-    grid: {};
+    // Map for monitoring the position of stones, giving quick access
+    map: Map<string, IStone>;
 
     constructor(private authService: AuthService, private http: HttpClient) {
-      this.grid = {};
+      this.map = new Map();
     }
 
     getStones() {
       return new Promise(resolve => {
         const self = this;
-        if (!this.stones) {
+        if (!this.stonesInventory) {
           this.http.post(environment.apiUrl + '/stones', {
             email: this.authService.user.email
           }).subscribe((res: [IStone]) => {
-            self.stones = res;
-            resolve(self.stones);
+            self.stonesInventory = res;
+            resolve(self.stonesInventory);
           });
         } else {
-           resolve(self.stones);
+           resolve(self.stonesInventory);
         }
       });
 
@@ -60,13 +62,13 @@ interface IStone {
       this.ctx = this.canvas.getContext('2d');
     }
     putStoneGrid(stone: IStone) {
-      this.grid[stone.x.toString() + ',' + stone.y.toString()] = stone;
+      this.map.set(stone.x.toString() + ',' + stone.y.toString(), stone);
     }
     getStoneGrid(x: number, y: number) {
-      return this.grid[x.toString() + ',' + y.toString()];
+      return this.map.get(x.toString() + ',' + y.toString());
     }
     removeStoneGrid(stone: IStone) {
-      delete this.grid[stone.x.toString() + ',' + stone.y.toString()];
+      this.map.delete(stone.x.toString() + ',' + stone.y.toString());
     }
 
     getMousePos(event) {
@@ -119,7 +121,7 @@ interface IStone {
     inventoryShow() {
       const x = 1;
       let y = 1;
-      this.stones.forEach((stone: IStone) => {
+      this.stonesInventory.forEach((stone: IStone) => {
         y += 2;
         stone.x = x;
         stone.y = y;

--- a/src/app/services/stones.service.ts
+++ b/src/app/services/stones.service.ts
@@ -89,7 +89,7 @@ interface IStone {
       };
     }
     clearStone(stone: IStone, position: IPixelPosition) {
-      this.ctx.putImageData(stone.background, position.x - this.stoneRadius - 5, position.y - this.stoneRadius - 5);
+      this.ctx.putImageData(stone.background, position.x - this.stoneRadius, position.y - this.stoneRadius);
     }
 
     writeMessage(message, x, y) {
@@ -105,10 +105,10 @@ interface IStone {
 
     drawStone(stone: IStone, position: IPixelPosition) {
       stone.background = this.ctx.getImageData(
-      position.x - this.stoneRadius - 5,
-      position.y - this.stoneRadius - 5,
-      this.stoneRadius * 2 + 10,
-      this.stoneRadius * 2 + 10);
+      position.x - this.stoneRadius,
+      position.y - this.stoneRadius,
+      this.stoneRadius * 2,
+      this.stoneRadius * 2);
       this.ctx.beginPath();
       if ( stone === null ) { return; }
       this.ctx.arc(position.x, position.y, this.stoneRadius, 0, 2 * Math.PI);

--- a/src/app/services/stones.service.ts
+++ b/src/app/services/stones.service.ts
@@ -14,6 +14,11 @@ interface IStone {
     drag: boolean;
   }
 
+  interface IPixelPosition {
+    x: number;
+    y: number;
+  }
+
 
   @Injectable({
     providedIn: 'root'
@@ -24,6 +29,7 @@ interface IStone {
     SERVER_URL: string;
 
     stones: IStone[];
+    dragPosition: IPixelPosition;
     canvas: HTMLCanvasElement;
     ctx: CanvasRenderingContext2D;
     stoneRadius = 10;
@@ -52,16 +58,16 @@ interface IStone {
       this.canvas = canvasRef.nativeElement;
       this.ctx = this.canvas.getContext('2d');
     }
-    getMousePos(evt) {
+    getMousePos(event) {
       const rect = this.canvas.getBoundingClientRect();
       return {
-        x: evt.clientX - rect.left,
-        y: evt.clientY - rect.top
+        x: event.clientX - rect.left,
+        y: event.clientY - rect.top
       };
     }
 
-    clearStone(stone: IStone) {
-      this.ctx.putImageData(stone.background, stone.x - this.stoneRadius - 5, stone.y - this.stoneRadius - 5);
+    clearStone(stone: IStone, position: IPixelPosition) {
+      this.ctx.putImageData(stone.background, position.x - this.stoneRadius - 5, position.y - this.stoneRadius - 5);
     }
 
     writeMessage(message, x, y) {
@@ -71,15 +77,15 @@ interface IStone {
       this.ctx.fillText(message, x, y);
     }
 
-    putStone(stone: IStone) {
+    putStone(stone: IStone, position: IPixelPosition) {
       stone.background = this.ctx.getImageData(
-      stone.x - this.stoneRadius - 5,
-      stone.y - this.stoneRadius - 5,
+      position.x - this.stoneRadius - 5,
+      position.y - this.stoneRadius - 5,
       this.stoneRadius * 2 + 10,
       this.stoneRadius * 2 + 10);
       this.ctx.beginPath();
       if ( stone === null ) { return; }
-      this.ctx.arc(stone.x, stone.y, this.stoneRadius, 0, 2 * Math.PI);
+      this.ctx.arc(position.x, position.y, this.stoneRadius, 0, 2 * Math.PI);
       this.ctx.fillStyle = stone.color;
       this.ctx.fill();
     }
@@ -92,7 +98,7 @@ interface IStone {
         stone.x = x;
         stone.y = y;
         stone.drag = false;
-        this.putStone(stone);
+        this.putStone(stone, stone);
       });
     }
     stoneTake(event) {
@@ -110,18 +116,20 @@ interface IStone {
     }
     stoneDrop(event) {
       if (!this.stone || !this.stone.drag) { return; }
-      this.clearStone(this.stone);
-      this.stone.x = this.getMousePos(event).x;
-      this.stone.y = this.getMousePos(event).y;
-      this.putStone(this.stone);
+      this.clearStone(this.stone, this.stone);
+      this.dragPosition = this.getMousePos(event);
+      this.stone.x = this.dragPosition.x; // <--- here caalculate
+      this.stone.y = this.dragPosition.y;
+      this.putStone(this.stone, this.dragPosition);
       this.stone.drag = false;
     }
     stoneDrag(event) {
       if (!this.stone || !this.stone.drag) { return; }
-      this.clearStone(this.stone);
-      this.stone.x = this.getMousePos(event).x;
-      this.stone.y = this.getMousePos(event).y;
-      this.putStone(this.stone);
+      this.clearStone(this.stone, this.stone);
+      this.dragPosition = this.getMousePos(event);
+      this.stone.x = this.dragPosition.x; // <--- here caalculate
+      this.stone.y = this.dragPosition.y;
+      this.putStone(this.stone, this.dragPosition);
     }
 
   }

--- a/src/app/ui/components/space/space.component.ts
+++ b/src/app/ui/components/space/space.component.ts
@@ -25,7 +25,7 @@ export class SpaceComponent implements OnInit {
 
   @ViewChild('canvas') canvasRef: ElementRef;
 
-  constructor(public stonesService: StonesService, public socket: SocketService) { 
+  constructor(public stonesService: StonesService, public socket: SocketService) {
 
     this.socket.emit('say_for_server', 'Hello Server').subscribe(
       (data) => {


### PR DESCRIPTION
Now, you can use common space. At first time there are stones on the inventory location. Now simple version, and there is inventory on first position (ordinat (x) x =1). 
Open another window of browser, and authorizate as another user (for example, login: admin@test.com, password: password)
 So you can move your stones, but you cannot move stones another user. But server wont remember postition your stones, it is next task.

P.S. I created infisible grid for stone. Stone have position x = 1 , 2, 3/ y = 1, 2, ,3 (real x = x * radius of stone * 2)